### PR TITLE
Align with Google TypeScript style.

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,9 +4,9 @@
 import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router'
 
+import {CohortBuilderComponent} from './cohort-builder.component'
 import {LoginComponent} from './login.component'
 import {SelectRepositoryComponent} from './select-repository.component'
-import {CohortBuilderComponent} from './cohort-builder.component'
 
 const routes: Routes = [
   {path: '', redirectTo: '/login', pathMatch: 'full'},

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,22 +1,22 @@
 // Based on the URL mapping in "routes" below, the RouterModule attaches
 // UI Components to the <router-outlet> element in the main AppComponent.
 
-import { NgModule }                  from '@angular/core';
-import { RouterModule, Routes }      from '@angular/router'
+import {NgModule} from '@angular/core';
+import {RouterModule, Routes} from '@angular/router'
 
-import { LoginComponent }            from './login.component'
-import { SelectRepositoryComponent } from './select-repository.component'
-import { CohortBuilderComponent }    from './cohort-builder.component'
+import {LoginComponent} from './login.component'
+import {SelectRepositoryComponent} from './select-repository.component'
+import {CohortBuilderComponent} from './cohort-builder.component'
 
 const routes: Routes = [
-  { path: '', redirectTo: '/login', pathMatch: 'full' },
-  { path: 'login', component: LoginComponent },
-  { path: 'repository', component: SelectRepositoryComponent },
-  { path: 'cohort/:id', component: CohortBuilderComponent }
+  {path: '', redirectTo: '/login', pathMatch: 'full'},
+  {path: 'login', component: LoginComponent},
+  {path: 'repository', component: SelectRepositoryComponent},
+  {path: 'cohort/:id', component: CohortBuilderComponent}
 ];
 
 @NgModule({
-  imports: [ RouterModule.forRoot(routes) ],
-  exports: [ RouterModule ]
+  imports: [RouterModule.forRoot(routes)],
+  exports: [RouterModule]
 })
 export class AppRoutingModule {}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,11 +1,11 @@
 // UI Component framing the overall app (title and nav).
 // Content is in other Components.
 
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   selector: 'aou-app',
-  styleUrls: [ './app.component.css' ],
+  styleUrls: ['./app.component.css'],
   template: `
     <h1>{{title}}</h1>
     <nav>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,22 +1,22 @@
 // Import all the pieces of the app centrally.
 
-import { BrowserModule }             from '@angular/platform-browser';
-import { FormsModule }               from '@angular/forms';
-import { NgModule }                  from '@angular/core';
-import { HttpModule }                from '@angular/http';
+import {BrowserModule} from '@angular/platform-browser';
+import {FormsModule} from '@angular/forms';
+import {NgModule} from '@angular/core';
+import {HttpModule} from '@angular/http';
 
-import { AppRoutingModule }          from './app-routing.module'
+import {AppRoutingModule} from './app-routing.module'
 
 // Imports for loading & configuring the in-memory web api
-import { InMemoryWebApiModule }      from 'angular-in-memory-web-api';
-import { InMemoryDataService }       from './in-memory-data.service';
+import {InMemoryWebApiModule} from 'angular-in-memory-web-api';
+import {InMemoryDataService} from './in-memory-data.service';
 
-import { AppComponent }              from './app.component';
-import { CohortBuilderComponent }    from './cohort-builder.component'
-import { LoginComponent }            from './login.component'
-import { RepositoryService }         from './repository.service'
-import { SelectRepositoryComponent } from './select-repository.component'
-import { UserService }               from './user.service'
+import {AppComponent} from './app.component';
+import {CohortBuilderComponent} from './cohort-builder.component'
+import {LoginComponent} from './login.component'
+import {RepositoryService} from './repository.service'
+import {SelectRepositoryComponent} from './select-repository.component'
+import {UserService} from './user.service'
 
 @NgModule({
   imports:      [
@@ -32,9 +32,9 @@ import { UserService }               from './user.service'
     SelectRepositoryComponent,
     CohortBuilderComponent
   ],
-  providers: [ UserService, RepositoryService ],
+  providers: [UserService, RepositoryService],
 
   // This specifies the top-level component, to load first.
-  bootstrap: [ AppComponent ]
+  bootstrap: [AppComponent]
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,18 +1,17 @@
 // Import all the pieces of the app centrally.
 
-import {BrowserModule} from '@angular/platform-browser';
-import {FormsModule} from '@angular/forms';
 import {NgModule} from '@angular/core';
+import {FormsModule} from '@angular/forms';
 import {HttpModule} from '@angular/http';
-
-import {AppRoutingModule} from './app-routing.module'
+import {BrowserModule} from '@angular/platform-browser';
 
 // Imports for loading & configuring the in-memory web api
 import {InMemoryWebApiModule} from 'angular-in-memory-web-api';
-import {InMemoryDataService} from './in-memory-data.service';
 
+import {AppRoutingModule} from './app-routing.module'
 import {AppComponent} from './app.component';
 import {CohortBuilderComponent} from './cohort-builder.component'
+import {InMemoryDataService} from './in-memory-data.service';
 import {LoginComponent} from './login.component'
 import {RepositoryService} from './repository.service'
 import {SelectRepositoryComponent} from './select-repository.component'

--- a/src/app/cohort-builder.component.ts
+++ b/src/app/cohort-builder.component.ts
@@ -1,39 +1,38 @@
 // View which wraps the third-party, plain javascript cohort browser widget.
 
-import { Component, OnInit }      from '@angular/core';
-import { ActivatedRoute, Params } from '@angular/router';
+import {Component, OnInit} from '@angular/core';
+import {ActivatedRoute, Params} from '@angular/router';
 
 import 'rxjs/add/operator/switchMap';
 
-import { User }                   from './user';
-import { Repository }             from './repository';
-import { RepositoryService }      from './repository.service';
+import {User} from './user';
+import {Repository} from './repository';
+import {RepositoryService} from './repository.service';
 
 const vaadinRootElementId = 'cohort-builder-widget';
-const vaadinConfig =
-  {
-    'theme': 'cohortbuilder',
-    'versionInfo': {'vaadinVersion': '7.7.5'},
-    'widgetset': 'org.vumc.ori.cohortbuilder.widgetsets.CohortBuilderWidgetSet',
-    'comErrMsg': {
-      'caption': 'Communication problem',
-      'message': 'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
-    },
-    'authErrMsg': {
-      'caption': 'Authentication problem',
-      'message': 'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
-    },
-    'sessExpMsg': {
-      'caption': 'Session Expired',
-      'message': 'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
-    },
-    'vaadinDir': 'https://35.185.116.214/pmi-cb/VAADIN/',
-    'debug': false,
-    'standalone': true,
-    'heartbeatInterval': 300,
-    'serviceUrl': 'https://35.185.116.214/pmi-cb/vaadinServlet/',
-    'browserDetailsUrl': 'https://35.185.116.214/pmi-cb/'
-  };
+const vaadinConfig = {
+  'theme': 'cohortbuilder',
+  'versionInfo': {'vaadinVersion': '7.7.5'},
+  'widgetset': 'org.vumc.ori.cohortbuilder.widgetsets.CohortBuilderWidgetSet',
+  'comErrMsg': {
+    'caption': 'Communication problem',
+    'message': 'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
+  },
+  'authErrMsg': {
+    'caption': 'Authentication problem',
+    'message': 'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
+  },
+  'sessExpMsg': {
+    'caption': 'Session Expired',
+    'message': 'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
+  },
+  'vaadinDir': 'https://35.185.116.214/pmi-cb/VAADIN/',
+  'debug': false,
+  'standalone': true,
+  'heartbeatInterval': 300,
+  'serviceUrl': 'https://35.185.116.214/pmi-cb/vaadinServlet/',
+  'browserDetailsUrl': 'https://35.185.116.214/pmi-cb/'
+};
 
 @Component({
   templateUrl: './cohort-builder.component.html'
@@ -46,7 +45,7 @@ export class CohortBuilderComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private repositoryService: RepositoryService
-  ) { }
+  ) {}
 
   ngOnInit(): void {
     this.route.params

--- a/src/app/cohort-builder.component.ts
+++ b/src/app/cohort-builder.component.ts
@@ -39,7 +39,8 @@ const vaadinConfig = {
 
 @Component({templateUrl: './cohort-builder.component.html'})
 export class CohortBuilderComponent implements OnInit {
-  vaadinJsUrl = 'https://35.185.116.214/pmi-cb/VAADIN/vaadinBootstrap.js?v=7.7.5'
+  vaadinJsUrl =
+      'https://35.185.116.214/pmi-cb/VAADIN/vaadinBootstrap.js?v=7.7.5';
 
   repository: Repository;
 
@@ -50,7 +51,8 @@ export class CohortBuilderComponent implements OnInit {
 
   ngOnInit(): void {
     this.route.params
-        .switchMap((params: Params) => this.repositoryService.get(+params['id']))
+        .switchMap(
+            (params: Params) => this.repositoryService.get(+params['id']))
         .subscribe(repository => {
           this.repository = repository;
           vaadin.initApplication(vaadinRootElementId, vaadinConfig);

--- a/src/app/cohort-builder.component.ts
+++ b/src/app/cohort-builder.component.ts
@@ -16,18 +16,15 @@ const vaadinConfig = {
   'widgetset': 'org.vumc.ori.cohortbuilder.widgetsets.CohortBuilderWidgetSet',
   'comErrMsg': {
     'caption': 'Communication problem',
-    'message':
-        'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
+    'message': 'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
   },
   'authErrMsg': {
     'caption': 'Authentication problem',
-    'message':
-        'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
+    'message': 'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
   },
   'sessExpMsg': {
     'caption': 'Session Expired',
-    'message':
-        'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
+    'message': 'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
   },
   'vaadinDir': 'https://35.185.116.214/pmi-cb/VAADIN/',
   'debug': false,

--- a/src/app/cohort-builder.component.ts
+++ b/src/app/cohort-builder.component.ts
@@ -1,13 +1,13 @@
 // View which wraps the third-party, plain javascript cohort browser widget.
 
+import 'rxjs/add/operator/switchMap';
+
 import {Component, OnInit} from '@angular/core';
 import {ActivatedRoute, Params} from '@angular/router';
 
-import 'rxjs/add/operator/switchMap';
-
-import {User} from './user';
 import {Repository} from './repository';
 import {RepositoryService} from './repository.service';
+import {User} from './user';
 
 const vaadinRootElementId = 'cohort-builder-widget';
 const vaadinConfig = {
@@ -16,15 +16,18 @@ const vaadinConfig = {
   'widgetset': 'org.vumc.ori.cohortbuilder.widgetsets.CohortBuilderWidgetSet',
   'comErrMsg': {
     'caption': 'Communication problem',
-    'message': 'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
+    'message':
+        'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
   },
   'authErrMsg': {
     'caption': 'Authentication problem',
-    'message': 'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
+    'message':
+        'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
   },
   'sessExpMsg': {
     'caption': 'Session Expired',
-    'message': 'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
+    'message':
+        'Take note of any unsaved data, and <u>click here</u> or press ESC to continue.',
   },
   'vaadinDir': 'https://35.185.116.214/pmi-cb/VAADIN/',
   'debug': false,
@@ -34,25 +37,23 @@ const vaadinConfig = {
   'browserDetailsUrl': 'https://35.185.116.214/pmi-cb/'
 };
 
-@Component({
-  templateUrl: './cohort-builder.component.html'
-})
+@Component({templateUrl: './cohort-builder.component.html'})
 export class CohortBuilderComponent implements OnInit {
   vaadinJsUrl = 'https://35.185.116.214/pmi-cb/VAADIN/vaadinBootstrap.js?v=7.7.5'
 
   repository: Repository;
 
   constructor(
-    private route: ActivatedRoute,
-    private repositoryService: RepositoryService
+      private route: ActivatedRoute,
+      private repositoryService: RepositoryService
   ) {}
 
   ngOnInit(): void {
     this.route.params
-      .switchMap((params: Params) => this.repositoryService.get(+params['id']))
-      .subscribe(repository => {
-        this.repository = repository;
-        vaadin.initApplication(vaadinRootElementId, vaadinConfig);
-      });
+        .switchMap((params: Params) => this.repositoryService.get(+params['id']))
+        .subscribe(repository => {
+          this.repository = repository;
+          vaadin.initApplication(vaadinRootElementId, vaadinConfig);
+        });
   }
 }

--- a/src/app/in-memory-data.service.ts
+++ b/src/app/in-memory-data.service.ts
@@ -1,9 +1,9 @@
 // An in-memory database to back the fake repository REST API.
 // RepositoryService uses Angular's http module to (fake) talk to this API.
 
-import { InMemoryDbService } from 'angular-in-memory-web-api';
+import {InMemoryDbService} from 'angular-in-memory-web-api';
 
-import { PermissionLevel } from './permission-level'
+import {PermissionLevel} from './permission-level'
 
 export class InMemoryDataService implements InMemoryDbService {
   createDb() {

--- a/src/app/in-memory-data.service.ts
+++ b/src/app/in-memory-data.service.ts
@@ -14,8 +14,8 @@ export class InMemoryDataService implements InMemoryDbService {
       {id: 14, permission: PermissionLevel.Registered, name: 'CDR 2017 Q1 v2'},
       {id: 15, permission: PermissionLevel.Registered, name: 'CDR 2017 Q1 v3'},
       {id: 16, permission: PermissionLevel.Registered, name: 'CDR 2017 Q2 v1'},
-      {id: 19, permission: PermissionLevel.Controlled, name: 'Row-Level 2017 Q1'},
-      {id: 20, permission: PermissionLevel.Controlled, name: 'Row-Level 2017 Q2'}
+      {id: 19, permission: PermissionLevel.Controlled, name: 'Raw 2017 Q1'},
+      {id: 20, permission: PermissionLevel.Controlled, name: 'Raw 2017 Q2'}
     ];
     return {repository};  // The variable name determines the fake API URL.
   }

--- a/src/app/login.component.ts
+++ b/src/app/login.component.ts
@@ -1,10 +1,10 @@
 // View for logging in and switching user / permission levels.
 
-import { Component, OnInit } from '@angular/core';
-import { Router }            from '@angular/router';
+import {Component, OnInit} from '@angular/core';
+import {Router} from '@angular/router';
 
-import { User }              from './user'
-import { UserService }       from './user.service'
+import {User} from './user'
+import {UserService} from './user.service'
 
 @Component({
   templateUrl: './login.component.html'
@@ -13,7 +13,7 @@ export class LoginComponent implements OnInit {
   constructor(
     private userService: UserService,
     private router: Router
-  ) { }
+  ) {}
 
   user: User;  // currently logged in, may be undefined
   login: User = new User();  // form data

--- a/src/app/login.component.ts
+++ b/src/app/login.component.ts
@@ -6,13 +6,11 @@ import {Router} from '@angular/router';
 import {User} from './user'
 import {UserService} from './user.service'
 
-@Component({
-  templateUrl: './login.component.html'
-})
+@Component({templateUrl: './login.component.html'})
 export class LoginComponent implements OnInit {
   constructor(
-    private userService: UserService,
-    private router: Router
+      private userService: UserService,
+      private router: Router
   ) {}
 
   user: User;  // currently logged in, may be undefined
@@ -20,17 +18,17 @@ export class LoginComponent implements OnInit {
 
   ngOnInit(): void {
     this.userService.getLoggedInUser()
-      .then(user => {
-        this.user = user
-        if (user) {
-          this.login = user
-        }
-      });
+        .then(user => {
+          this.user = user
+          if (user) {
+            this.login = user
+          }
+        });
   }
 
   logIn(): void {
     this.userService.logIn(this.login.name, this.login.permission)
-      .then(() => this.goToSelectRepository());
+        .then(() => this.goToSelectRepository());
   }
 
   goToSelectRepository(): void {
@@ -39,6 +37,6 @@ export class LoginComponent implements OnInit {
 
   logOut(): void {
     this.userService.logOut()
-      .then(() => this.ngOnInit());
+        .then(() => this.ngOnInit());
   }
 }

--- a/src/app/repository.service.ts
+++ b/src/app/repository.service.ts
@@ -1,19 +1,19 @@
 // Data interface for getting details about available CDRs. This communicates
 // via Angular's builtin Http module with a (fake) REST API.
 
-import { Injectable } from '@angular/core';
-import { Headers, Http } from '@angular/http';
+import {Injectable} from '@angular/core';
+import {Headers, Http} from '@angular/http';
 
 import 'rxjs/add/operator/toPromise';
 
-import { Repository } from './repository';
+import {Repository} from './repository';
 
 @Injectable()
 export class RepositoryService {
   private apiUrl = 'api/repository';  // URL to (fake in-memory) web API
   private headers = new Headers({'Content-Type': 'application/json'});
 
-  constructor(private http: Http) { }
+  constructor(private http: Http) {}
 
   list(): Promise<Repository[]> {
     return this.http

--- a/src/app/repository.service.ts
+++ b/src/app/repository.service.ts
@@ -1,10 +1,10 @@
 // Data interface for getting details about available CDRs. This communicates
 // via Angular's builtin Http module with a (fake) REST API.
 
+import 'rxjs/add/operator/toPromise';
+
 import {Injectable} from '@angular/core';
 import {Headers, Http} from '@angular/http';
-
-import 'rxjs/add/operator/toPromise';
 
 import {Repository} from './repository';
 
@@ -17,22 +17,22 @@ export class RepositoryService {
 
   list(): Promise<Repository[]> {
     return this.http
-      .get(this.apiUrl)
-      .toPromise()
-      .then(response => response.json().data as Repository[])
-      .catch(this.handleError);
+        .get(this.apiUrl)
+        .toPromise()
+        .then(response => response.json().data as Repository[])
+        .catch(this.handleError);
   }
 
   get(id: number): Promise<Repository> {
     return this.http
-      .get(`${this.apiUrl}/${id}`)
-      .toPromise()
-      .then(response => response.json().data as Repository)
-      .catch(this.handleError);
+        .get(`${this.apiUrl}/${id}`)
+        .toPromise()
+        .then(response => response.json().data as Repository)
+        .catch(this.handleError);
   }
 
   private handleError(error: any): Promise<any> {
-    console.error('An error occurred', error); // for demo purposes only
+    console.error('An error occurred', error);  // for demo purposes only
     return Promise.reject(error.message || error);
   }
 }

--- a/src/app/repository.ts
+++ b/src/app/repository.ts
@@ -1,6 +1,6 @@
 // A Curated Data Repository which a user might browse to build a cohort.
 
-import { PermissionLevel } from './permission-level';
+import {PermissionLevel} from './permission-level';
 
 export class Repository {
   id: number;

--- a/src/app/select-repository.component.ts
+++ b/src/app/select-repository.component.ts
@@ -4,13 +4,13 @@
 // elements). In a real server, these would of course need to be enforced
 // server-side.
 
-import { Component, OnInit } from '@angular/core';
-import { Router }            from '@angular/router';
+import {Component, OnInit} from '@angular/core';
+import {Router} from '@angular/router';
 
-import { User }              from './user';
-import { UserService }       from './user.service';
-import { Repository }        from './repository';
-import { RepositoryService } from './repository.service';
+import {User} from './user';
+import {UserService} from './user.service';
+import {Repository} from './repository';
+import {RepositoryService} from './repository.service';
 
 @Component({
   templateUrl: './select-repository.component.html'

--- a/src/app/select-repository.component.ts
+++ b/src/app/select-repository.component.ts
@@ -7,29 +7,27 @@
 import {Component, OnInit} from '@angular/core';
 import {Router} from '@angular/router';
 
-import {User} from './user';
-import {UserService} from './user.service';
 import {Repository} from './repository';
 import {RepositoryService} from './repository.service';
+import {User} from './user';
+import {UserService} from './user.service';
 
-@Component({
-  templateUrl: './select-repository.component.html'
-})
+@Component({templateUrl: './select-repository.component.html'})
 export class SelectRepositoryComponent implements OnInit {
   repositories: Repository[] = [];
   user: User;
 
   constructor(
-    private router: Router,
-    private userService: UserService,
-    private repositoryService: RepositoryService
+      private router: Router,
+      private userService: UserService,
+      private repositoryService: RepositoryService
   ) {}
 
   ngOnInit(): void {
     this.userService.getLoggedInUser()
-      .then(user => this.user = user);
+        .then(user => this.user = user);
     this.repositoryService.list()
-      .then(repositories => this.repositories = repositories);
+        .then(repositories => this.repositories = repositories);
   }
 
   goToCohort(id: number): void {

--- a/src/app/user.service.ts
+++ b/src/app/user.service.ts
@@ -5,12 +5,13 @@
 
 import {Injectable} from '@angular/core';
 
-import {User} from './user';
 import {PermissionLevel} from './permission-level';
+import {User} from './user';
 
 @Injectable()
 export class UserService {
-  private user: User = {id: 1, name: 'All of Us User', permission: PermissionLevel.Public}
+  private user:
+      User = {id: 1, name: 'All of Us User', permission: PermissionLevel.Public}
 
   getLoggedInUser(): Promise<User> {
     return Promise.resolve(this.user);

--- a/src/app/user.service.ts
+++ b/src/app/user.service.ts
@@ -3,10 +3,10 @@
 //
 // A default user is logged in by default.
 
-import { Injectable } from '@angular/core';
+import {Injectable} from '@angular/core';
 
-import { User } from './user';
-import { PermissionLevel } from './permission-level';
+import {User} from './user';
+import {PermissionLevel} from './permission-level';
 
 @Injectable()
 export class UserService {

--- a/src/app/user.service.ts
+++ b/src/app/user.service.ts
@@ -10,8 +10,7 @@ import {User} from './user';
 
 @Injectable()
 export class UserService {
-  private user:
-      User = {id: 1, name: 'All of Us User', permission: PermissionLevel.Public}
+  private user: User = {id: 1, name: 'All of Us User', permission: PermissionLevel.Public}
 
   getLoggedInUser(): Promise<User> {
     return Promise.resolve(this.user);

--- a/src/app/user.ts
+++ b/src/app/user.ts
@@ -1,6 +1,6 @@
 // A client user, simulating login via Google or OAuth in a browser.
 
-import { PermissionLevel } from './permission-level';
+import {PermissionLevel} from './permission-level';
 
 export class User {
   id: number;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 // The main file is boilerplate; AppModule configures our app.
 
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 
-import { AppModule } from './app/app.module';
+import {AppModule} from './app/app.module';
 
 platformBrowserDynamic().bootstrapModule(AppModule);

--- a/src/systemjs-angular-loader.js
+++ b/src/systemjs-angular-loader.js
@@ -2,7 +2,7 @@ var templateUrlRegex = /templateUrl\s*:(\s*['"`](.*?)['"`]\s*)/gm;
 var stylesRegex = /styleUrls *:(\s*\[[^\]]*?\])/g;
 var stringRegex = /(['`"])((?:[^\\]\\\1|.)*?)\1/g;
 
-module.exports.translate = function(load){
+module.exports.translate = function(load) {
   if (load.source.indexOf('moduleId') != -1) return load;
 
   var url = document.createElement('a');
@@ -17,33 +17,36 @@ module.exports.translate = function(load){
   baseHref.href = this.baseURL;
   baseHref = baseHref.pathname;
 
-  if (!baseHref.startsWith('/base/')) { // it is not karma
+  if (!baseHref.startsWith('/base/')) {  // it is not karma
     basePath = basePath.replace(baseHref, '');
   }
 
-  load.source = load.source
-    .replace(templateUrlRegex, function(match, quote, url){
-      var resolvedUrl = url;
+  load.source =
+      load.source
+          .replace(
+              templateUrlRegex,
+              function(match, quote, url) {
+                var resolvedUrl = url;
 
-      if (url.startsWith('.')) {
-        resolvedUrl = basePath + url.substr(1);
-      }
+                if (url.startsWith('.')) {
+                  resolvedUrl = basePath + url.substr(1);
+                }
 
-      return 'templateUrl: "' + resolvedUrl + '"';
-    })
-    .replace(stylesRegex, function(match, relativeUrls) {
-      var urls = [];
+                return 'templateUrl: "' + resolvedUrl + '"';
+              })
+          .replace(stylesRegex, function(match, relativeUrls) {
+            var urls = [];
 
-      while ((match = stringRegex.exec(relativeUrls)) !== null) {
-        if (match[2].startsWith('.')) {
-          urls.push('"' + basePath + match[2].substr(1) + '"');
-        } else {
-          urls.push('"' + match[2] + '"');
-        }
-      }
+            while ((match = stringRegex.exec(relativeUrls)) !== null) {
+              if (match[2].startsWith('.')) {
+                urls.push('"' + basePath + match[2].substr(1) + '"');
+              } else {
+                urls.push('"' + match[2] + '"');
+              }
+            }
 
-      return "styleUrls: [" + urls.join(', ') + "]";
-    });
+            return 'styleUrls: [' + urls.join(', ') + ']';
+          });
 
   return load;
 };

--- a/src/systemjs.config.js
+++ b/src/systemjs.config.js
@@ -2,44 +2,42 @@
  * System configuration for Angular samples
  * Adjust as necessary for your application needs.
  */
-(function (global) {
-  System.config({
-    paths: {
-      // paths serve as alias
-      'npm:': 'node_modules/'
-    },
-    // map tells the System loader where to look for things
-    map: {
-      // our app is within the app folder
-      'app': 'app',
+(function(global) {
+System.config({
+  paths: {
+    // paths serve as alias
+    'npm:': 'node_modules/'
+  },
+  // map tells the System loader where to look for things
+  map: {
+    // our app is within the app folder
+    'app': 'app',
 
-      // angular bundles
-      '@angular/core': 'npm:@angular/core/bundles/core.umd.js',
-      '@angular/common': 'npm:@angular/common/bundles/common.umd.js',
-      '@angular/compiler': 'npm:@angular/compiler/bundles/compiler.umd.js',
-      '@angular/platform-browser': 'npm:@angular/platform-browser/bundles/platform-browser.umd.js',
-      '@angular/platform-browser-dynamic': 'npm:@angular/platform-browser-dynamic/bundles/platform-browser-dynamic.umd.js',
-      '@angular/http': 'npm:@angular/http/bundles/http.umd.js',
-      '@angular/router': 'npm:@angular/router/bundles/router.umd.js',
-      '@angular/forms': 'npm:@angular/forms/bundles/forms.umd.js',
+    // angular bundles
+    '@angular/core': 'npm:@angular/core/bundles/core.umd.js',
+    '@angular/common': 'npm:@angular/common/bundles/common.umd.js',
+    '@angular/compiler': 'npm:@angular/compiler/bundles/compiler.umd.js',
+    '@angular/platform-browser':
+        'npm:@angular/platform-browser/bundles/platform-browser.umd.js',
+    '@angular/platform-browser-dynamic':
+        'npm:@angular/platform-browser-dynamic/bundles/platform-browser-dynamic.umd.js',
+    '@angular/http': 'npm:@angular/http/bundles/http.umd.js',
+    '@angular/router': 'npm:@angular/router/bundles/router.umd.js',
+    '@angular/forms': 'npm:@angular/forms/bundles/forms.umd.js',
 
-      // other libraries
-      'rxjs':                      'npm:rxjs',
-      'angular-in-memory-web-api': 'npm:angular-in-memory-web-api/bundles/in-memory-web-api.umd.js'
+    // other libraries
+    'rxjs': 'npm:rxjs',
+    'angular-in-memory-web-api':
+        'npm:angular-in-memory-web-api/bundles/in-memory-web-api.umd.js'
+  },
+  // packages tells the System loader how to load when no filename and/or no
+  // extension
+  packages: {
+    app: {
+      defaultExtension: 'js',
+      meta: {'./*.js': {loader: 'systemjs-angular-loader.js'}}
     },
-    // packages tells the System loader how to load when no filename and/or no extension
-    packages: {
-      app: {
-        defaultExtension: 'js',
-        meta: {
-          './*.js': {
-            loader: 'systemjs-angular-loader.js'
-          }
-        }
-      },
-      rxjs: {
-        defaultExtension: 'js'
-      }
-    }
-  });
+    rxjs: {defaultExtension: 'js'}
+  }
+});
 })(this);


### PR DESCRIPTION
* Remove extra whitespace within and around braces (including imports).
* Indent +4 spaces when wrapping an expression.
* Wrap to 80 columns.
* 2 spaces after a line before an inline comment.

I chose to ignore some of the auto-formatter's suggestions:
* Leave some annotation's dictionaries on multiple lines.
* Prefer to break all chained calls onto new lines (as opposed to putting http.get() on one line and then breaking subsequent chained calls).

Before too long, we should look into setting up a linter. For PMI, we set up a linter as a git pre-push hook, which has worked out pretty well.